### PR TITLE
Remove useless half of fft

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,5 +16,5 @@ function frequencies (input) {
   fft(1, reals, imags)
   mag(reals, reals, imags)
 
-  return reals
+  return reals.hi(data.length / 2)
 }


### PR DESCRIPTION
The top half of the fft is just the mirror of the bottom half. Think we can just discard it. @ahdinosaur 
